### PR TITLE
CGP-1256: Update Engagement Points Custom Field When Attached Actions Are Triggered.

### DIFF
--- a/CRM/CiviEngagementScoring/Rules/Actions/ContactEngagementScore.php
+++ b/CRM/CiviEngagementScoring/Rules/Actions/ContactEngagementScore.php
@@ -3,6 +3,11 @@
 class CRM_CiviEngagementScoring_Rules_Actions_ContactEngagementScore extends CRM_Civirules_Action {
 
   /**
+   * @var string
+   */
+  private $engagementPointsCustomFieldId = '';
+
+  /**
    * Method to return the url for additional form processing for action
    * and return false if none is needed
    *
@@ -18,7 +23,6 @@ class CRM_CiviEngagementScoring_Rules_Actions_ContactEngagementScore extends CRM
    * Method processAction to execute the action
    *
    * @param CRM_Civirules_TriggerData_TriggerData $triggerData
-   * @access public
    *
    */
   public function processAction(CRM_Civirules_TriggerData_TriggerData $triggerData) {
@@ -30,5 +34,56 @@ class CRM_CiviEngagementScoring_Rules_Actions_ContactEngagementScore extends CRM
     if (!empty($params['engagement_points'])) {
       return "Points: ". $params['engagement_points'];
     }
+  }
+
+  /**
+   * Returns the contact's engagement points
+   *
+   * @param int $contactID
+   */
+  protected function getContactEngagementPoints($contactID) {
+    $customFieldName = "custom_" . $this->getEngagementPointsCustomFieldId();
+    $engagementPoints = 0;
+    $result = civicrm_api3('Contact', 'getsingle', [
+      'return' => [$customFieldName],
+      'id' => $contactID,
+    ]);
+
+    if (!empty($result[$customFieldName])) {
+      $engagementPoints = $result[$customFieldName];
+    }
+
+    return $engagementPoints;
+  }
+
+  /**
+   * Updates the contact's engagement points.
+   *
+   * @param int $contactID
+   * @param mixed $engagementPoints
+   */
+  protected function updateContactEngagementPoints($contactID, $engagementPoints) {
+    $customFieldName = "custom_" . $this->getEngagementPointsCustomFieldId();
+    civicrm_api3('Contact', 'create', [
+      'id' => $contactID,
+      "$customFieldName" => $engagementPoints
+    ]);
+  }
+
+  /**
+   * Returns the custom field id for the engagement points custom field.
+   *
+   * @return string
+   */
+  protected function getEngagementPointsCustomFieldId() {
+    if (empty($this->engagementPointsCustomFieldId)) {
+      $this->engagementPointsCustomFieldId = CRM_Core_BAO_CustomField::getCustomFieldID(
+        'Engagement_Points',
+        'Engagement Scoring'
+      );
+    }
+
+
+    return $this->engagementPointsCustomFieldId;
   }
 }

--- a/CRM/CiviEngagementScoring/Rules/Actions/DecreaseEngagementScore.php
+++ b/CRM/CiviEngagementScoring/Rules/Actions/DecreaseEngagementScore.php
@@ -1,0 +1,30 @@
+<?php
+
+use CRM_CiviEngagementScoring_Rules_Actions_ContactEngagementScore as ContactEngagementScore;
+
+class CRM_CiviEngagementScoring_Rules_Actions_DecreaseEngagementScore extends ContactEngagementScore {
+
+  /**
+   * Method processAction to execute the action. Basically the contact engagement
+   * points is decreased by the number of points set for the action.
+   *
+   * @param CRM_Civirules_TriggerData_TriggerData $triggerData
+   *
+   */
+  public function processAction(CRM_Civirules_TriggerData_TriggerData $triggerData) {
+    $contactId = $triggerData->getContactId();
+    $params = $this->getActionParameters();
+
+    if (!empty($params['engagement_points'])) {
+      $contactEngagementPoints = $this->getContactEngagementPoints($contactId);
+      $actionEngagementPoints = $params['engagement_points'];
+      $updatedEngagementPoints = $contactEngagementPoints - $actionEngagementPoints;
+      $updatedPoints = $updatedEngagementPoints < 0 ? 0 : $updatedEngagementPoints;
+
+      $this->updateContactEngagementPoints(
+        $contactId,
+        $updatedPoints
+      );
+    }
+  }
+}

--- a/CRM/CiviEngagementScoring/Rules/Actions/IncreaseEngagementScore.php
+++ b/CRM/CiviEngagementScoring/Rules/Actions/IncreaseEngagementScore.php
@@ -1,0 +1,28 @@
+<?php
+
+use CRM_CiviEngagementScoring_Rules_Actions_ContactEngagementScore as ContactEngagementScore;
+
+class CRM_CiviEngagementScoring_Rules_Actions_IncreaseEngagementScore extends ContactEngagementScore {
+
+  /**
+   * Method processAction to execute the action. Basically the contact engagement
+   * points is increased by the number of points set for the action.
+   *
+   * @param CRM_Civirules_TriggerData_TriggerData $triggerData
+   *
+   */
+  public function processAction(CRM_Civirules_TriggerData_TriggerData $triggerData) {
+    $contactId = $triggerData->getContactId();
+    $params = $this->getActionParameters();
+
+    if (!empty($params['engagement_points'])) {
+      $contactEngagementPoints = $this->getContactEngagementPoints($contactId);
+      $actionEngagementPoints = $params['engagement_points'];
+
+      $this->updateContactEngagementPoints(
+        $contactId,
+        ($contactEngagementPoints + $actionEngagementPoints)
+      );
+    }
+  }
+}

--- a/sql/create_engagement_action.sql
+++ b/sql/create_engagement_action.sql
@@ -1,5 +1,5 @@
 INSERT INTO civirule_action
 (name, label, class_name, is_active)
 VALUES
-("decrease_engagement_score", "Increase engagement score by X points", "CRM_CiviEngagementScoring_Rules_Actions_ContactEngagementScore", 1),
-("increase_engagement_score", "Decrease engagement score by X points", "CRM_CiviEngagementScoring_Rules_Actions_ContactEngagementScore", 1);
+("decrease_engagement_score", "Increase engagement score by X points", "CRM_CiviEngagementScoring_Rules_Actions_IncreaseEngagementScore", 1),
+("increase_engagement_score", "Decrease engagement score by X points", "CRM_CiviEngagementScoring_Rules_Actions_DecreaseEngagementScore", 1);


### PR DESCRIPTION
## Overview
This PR adds the functionality to update the engagement points custom field in order to update the engagement scoring widget whenever the trigger attached to the action is triggered for the contact.

The engagement scoring civirules actions has action for increasing or decreasing an engagement score.

## Before
The Engagement point custom field has to be updated manually before the change is reflected on the widget.

## After
The Engagement point custom field is updated when the trigger the action is attached to takes is invoked.

In the screenshot below, the Engagement points is to be increased by 3 points when a phone number is added to a contact for a particular rule.

<img width="1154" alt="Find CiviRules Rules  mastercore 2019-03-12 10-14-10" src="https://user-images.githubusercontent.com/6951813/54189673-92d7e280-44b2-11e9-9dc9-315010a72ef3.png">

The GIF shows what happens when a phone number is actually added to the contact.

![CiviEngagement](https://user-images.githubusercontent.com/6951813/54189759-c31f8100-44b2-11e9-8289-cbd1926941ab.gif)

 
